### PR TITLE
fix retest report bug

### DIFF
--- a/lib/App/Ikaros/Reporter.pm
+++ b/lib/App/Ikaros/Reporter.pm
@@ -188,7 +188,7 @@ sub __retest {
     };
 
     return map {
-        if ($_ =~ /\A(.*?)\s*\(Wstat: [0-9]/ms) {
+        if ($_ =~ /\A(.*?)\s*\(Wstat: [0-9]+ Tests: [0-9]+ Failed: [1-9]/ms) {
             $1;
         } else {
             ();

--- a/lib/App/Ikaros/Reporter.pm
+++ b/lib/App/Ikaros/Reporter.pm
@@ -188,7 +188,7 @@ sub __retest {
     };
 
     return map {
-        if ($_ =~ /\A(.*?)\s*\(Wstat: [1-9]/ms) {
+        if ($_ =~ /\A(.*?)\s*\(Wstat: [0-9]/ms) {
             $1;
         } else {
             ();


### PR DESCRIPTION
retestでfailしたテストがあるのに、テストが成功になる場合がある問題を修正しました。

一回目のテストでは、Failedは各serverから帰ってきたxmlから取得していて問題は無かったのですが、

その失敗したテストケースをretestしたときに、
失敗したテストケースの取得をコンソール出力からパースしていて、

テスト結果の出力が
```
Test Summary Report
-------------------
t/foo.t (Wstat: 0 Tests: 3 Failed: 1)
  Failed test:  1
Files=1, Tests=3, 20.975 wallclock secs ( 0.03 usr  0.00 sys + 20.02 cusr  0.66 csys = 20.71 CPU)
Result: FAIL
```
の用に Wstat:0 で帰ってきた場合に t/var.t を Fail扱いに出来ていませんでした。

`(Wstat: 0` で返ってきてもFail扱いになるように正規表現を修正しました。