### PR TITLE
Wstat, Failed の両方を見て失敗検知するように修正

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -15,6 +15,7 @@ on build => sub {
     requires 'IPC::Run';
     requires 'XML::Simple';
     requires 'Devel::Cover';
+    requires 'File::Copy::Recursive';
 };
 
 on test => sub {

--- a/t/App-Ikaros-Reporter.t
+++ b/t/App-Ikaros-Reporter.t
@@ -1,0 +1,45 @@
+use strict;
+use warnings;
+use Test::More;
+use App::Ikaros::Reporter;
+
+BEGIN { use_ok 'App::Ikaros::Reporter' }
+
+subtest 'parse_failed_tests_from_output' => sub {
+
+    subtest 'empty' => sub {
+        ok !App::Ikaros::Reporter->parse_failed_tests_from_output("");
+    };
+
+    subtest 'Multiple tests' => sub {
+        my @failed = App::Ikaros::Reporter->parse_failed_tests_from_output(<<OUTPUT);
+t/test1.t                                                       (Wstat: 256 Tests: 7 Failed: 0)
+  Failed test:  6
+t/test2.t                                                        (Wstat: 0 Tests: 3 Failed: 1)
+  Failed test:  3
+
+OUTPUT
+        is_deeply \@failed, [ qw(
+            t/test1.t
+            t/test2.t
+        ) ];
+    };
+
+    subtest 'Wstat:0 Failed:>0' => sub {
+        my @failed = App::Ikaros::Reporter->parse_failed_tests_from_output(<<OUTPUT);
+t/test1.t                                                       (Wstat: 0 Tests: 7 Failed: 1)
+  Failed test:  6
+OUTPUT
+        is_deeply \@failed, [ 't/test1.t' ];
+    };
+
+    subtest 'Wstat:>0 Failed:0' => sub {
+        my @failed = App::Ikaros::Reporter->parse_failed_tests_from_output(<<OUTPUT);
+t/test1.t                                                       (Wstat: 256 Tests: 7 Failed: 0)
+  Failed test:  6
+OUTPUT
+        is_deeply \@failed, [ 't/test1.t' ];
+    };
+};
+
+done_testing;


### PR DESCRIPTION
retestでfailしたテストがあるのに、テストが成功になる場合がある問題を修正しました。( #2のやり直し)

一回目のテストでは、Failedは各serverから帰ってきたxmlから取得していて問題は無かったのですが、

その失敗したテストケースをretestしたときに、
失敗したテストケースの取得をコンソール出力からパースしていて、

テスト結果の出力が
```
Test Summary Report
-------------------
t/foo.t (Wstat: 0 Tests: 3 Failed: 1)
  Failed test:  1
Files=1, Tests=3, 20.975 wallclock secs ( 0.03 usr  0.00 sys + 20.02 cusr  0.66 csys = 20.71 CPU)
Result: FAIL
```
の用に Wstat:0 で帰ってきた場合に t/var.t を Fail扱いに出来ていませんでした。
テスト自体でsystemcallをしている場合に発生するみたいです。

テストが感想しなかった場合はは、従来通り Wstatが0以外になるので、
Wstat, Failedの両方をみて失敗と判断するようにしました。