### PR TITLE
support $ENV{PERL_FORKPROVE_IGNORE}

### DIFF
--- a/lib/App/Ikaros/LandingPoint.pm
+++ b/lib/App/Ikaros/LandingPoint.pm
@@ -20,6 +20,7 @@ __PACKAGE__->mk_accessors(qw/
     output_filename
     dot_prove_filename
     cover_db_name
+    forkprove_ignore_env
 /);
 
 sub new {
@@ -66,7 +67,8 @@ sub new {
         trigger_filename => $trigger_filename,
         output_filename  => $output_filename,
         dot_prove_filename => $dot_prove_filename,
-        cover_db_name    => $cover_db_name
+        cover_db_name    => $cover_db_name,
+        forkprove_ignore_env => '',
     });
 }
 

--- a/lib/App/Ikaros/Planner.pm
+++ b/lib/App/Ikaros/Planner.pm
@@ -14,6 +14,7 @@ use constant {
 __PACKAGE__->mk_accessors(qw/
     prove_tests
     forkprove_tests
+    blacklist
     saved_tests
     sorted_tests
 /);
@@ -34,6 +35,11 @@ sub planning {
     my ($self, $host, $args) = @_;
     my $commands = $self->__make_command($args, $host);
     $host->plan($commands);
+
+    if (@{ $self->blacklist || [] }) {
+        my $forkprove_ignore_regexp = join '|', (map { quotemeta } @{$self->blacklist});
+        $host->forkprove_ignore_env('\A(?:' . $forkprove_ignore_regexp . ')\z');
+    }
 }
 
 sub __load_prove_state {


### PR DESCRIPTION
`forkprove` can select a command(prove or forkprove) for each file.

https://github.com/miyagawa/forkprove/blob/009776a3fbf682ff4c7e707aa2159c93b0f0a8f7/lib/App/ForkProve/SourceHandler.pm#L27


This PR can further reduce the server cost because we don't need to prepare dedicated prove server.

